### PR TITLE
Add tests for simulation reproduction and network viz

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -53,6 +53,7 @@ class Simulation {
     }
 }
 
+if (typeof window !== 'undefined') {
 window.addEventListener('load', () => {
     const btn = document.getElementById('startBtn');
     btn.addEventListener('click', () => {
@@ -80,3 +81,8 @@ window.addEventListener('load', () => {
         sim.start();
     });
 });
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = Simulation;
+}

--- a/js/network_viz.js
+++ b/js/network_viz.js
@@ -53,3 +53,8 @@ class NetworkViz {
         ctx.fill();
     }
 }
+
+if (typeof module !== 'undefined') {
+    module.exports = NetworkViz;
+}
+

--- a/test/network_viz.test.js
+++ b/test/network_viz.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const NetworkViz = require('../js/network_viz.js');
+
+global.document = { getElementById: () => ({ getContext: () => ({}) }) };
+
+test('NetworkViz node positions are evenly spaced', () => {
+  const viz = new NetworkViz('c');
+  const pos = viz._nodePositions(4, 100);
+  assert.deepStrictEqual(pos, [20, 40, 60, 80]);
+});
+

--- a/test/simulation.test.js
+++ b/test/simulation.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// Globals required by Ant
+global.Brain = require('../js/brain.js');
+global.Sensors = require('../js/sensors.js');
+global.Actors = require('../js/actors.js');
+global.Environment = require('../js/environment.js');
+global.Ant = require('../js/ant.js');
+global.NetworkViz = require('../js/network_viz.js');
+const Simulation = require('../js/main.js');
+
+// minimal DOM stubs
+global.document = {
+  getElementById: () => ({ getContext: () => ({}) })
+};
+
+test('Simulation reproduces when energy threshold exceeded', () => {
+  const sim = new Simulation('canvas', 1, {
+    maxAnts: 2,
+    reproductionEnergyThreshold: 50,
+    reproductionEnergyCost: 5,
+    energyDecayRate: 0
+  });
+  sim.ants[0].energy = 60;
+  sim.update();
+  assert.strictEqual(sim.ants.length, 2);
+  assert.strictEqual(Math.round(sim.ants[0].energy), 55);
+});
+
+test('Simulation respects maximum ant count', () => {
+  const sim = new Simulation('canvas', 2, {
+    maxAnts: 2,
+    reproductionEnergyThreshold: 10,
+    reproductionEnergyCost: 0,
+    energyDecayRate: 0
+  });
+  sim.ants.forEach(a => a.energy = 20);
+  sim.update();
+  assert.strictEqual(sim.ants.length, 2);
+});
+
+


### PR DESCRIPTION
## Summary
- export `Simulation` and `NetworkViz` for use in Node tests
- guard `window.addEventListener` usage in `main.js`
- test reproduction logic in `Simulation`
- test `_nodePositions` helper of `NetworkViz`

## Testing
- `npm test`