### PR TITLE
Display brain activations

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,9 @@ runs without any build step; simply open `main.html` in a browser.
   from the beginning of the simulation. Responsible for updating and rendering
   everything each frame.
 - **NetworkViz**: Renders the neural network of the first ant onto a small
-  canvas so that weights and topology can be observed.
+  canvas so that weights, topology and current neuron activations can be
+  observed. Node labels describe the meaning of each input and output
+  signal.
 
 Each component is implemented as a plain JavaScript class in the `js/`
 folder. The classes are intentionally lightweight so that the demo loads

--- a/js/brain.js
+++ b/js/brain.js
@@ -27,9 +27,11 @@ class Brain {
     }
 
     process(inputs) {
+        this.lastInput = inputs.slice();
         const hidden = this.weights1.map(row =>
             sigmoid(row.reduce((sum, w, i) => sum + w * inputs[i], 0))
         );
+        this.lastHidden = hidden.slice();
         const raw = this.weights2.map(row =>
             row.reduce((sum, w, i) => sum + w * hidden[i], 0)
         );
@@ -37,7 +39,8 @@ class Brain {
         const dirX = raw[0] / mag;
         const dirY = raw[1] / mag;
         const speed = inputs[2];
-        return [dirX, dirY, speed];
+        this.lastOutput = [dirX, dirY, speed];
+        return this.lastOutput;
     }
 }
 

--- a/js/network_viz.js
+++ b/js/network_viz.js
@@ -13,6 +13,13 @@ class NetworkViz {
         const hiddenY = this._nodePositions(brain.hiddenSize, this.canvas.height);
         const outputY = this._nodePositions(brain.outputSize, this.canvas.height);
 
+        const inputActs = brain.lastInput || Array(brain.inputSize).fill(0);
+        const hiddenActs = brain.lastHidden || Array(brain.hiddenSize).fill(0);
+        const outputActs = brain.lastOutput || Array(brain.outputSize).fill(0);
+
+        const inputLabels = ['dirX', 'dirY', 'dist'];
+        const outputLabels = ['moveX', 'moveY', 'speed'];
+
         // connections input->hidden
         ctx.strokeStyle = '#999';
         for (let i = 0; i < brain.hiddenSize; i++) {
@@ -28,9 +35,23 @@ class NetworkViz {
         }
         // nodes
         ctx.fillStyle = '#222';
-        inputY.forEach(y => this._circle(layerX[0], y, radius));
-        hiddenY.forEach(y => this._circle(layerX[1], y, radius));
-        outputY.forEach(y => this._circle(layerX[2], y, radius));
+        ctx.textAlign = 'center';
+        ctx.font = '10px Arial';
+        inputY.forEach((y, i) => {
+            this._circle(layerX[0], y, radius);
+            ctx.fillText(inputActs[i].toFixed(2), layerX[0], y - 8);
+            ctx.fillText(inputLabels[i] || `I${i}`, layerX[0], y + 12);
+        });
+        hiddenY.forEach((y, i) => {
+            this._circle(layerX[1], y, radius);
+            ctx.fillText(hiddenActs[i].toFixed(2), layerX[1], y - 8);
+            ctx.fillText(`H${i + 1}`, layerX[1], y + 12);
+        });
+        outputY.forEach((y, i) => {
+            this._circle(layerX[2], y, radius);
+            ctx.fillText(outputActs[i].toFixed(2), layerX[2], y - 8);
+            ctx.fillText(outputLabels[i] || `O${i + 1}`, layerX[2], y + 12);
+        });
     }
 
     _nodePositions(count, height) {

--- a/readme.md
+++ b/readme.md
@@ -9,14 +9,16 @@ Open `main.html` in any modern browser. The page will display a canvas with a
 population of ants seeking out food that appears over time. Before starting you
 can set how many ants to spawn and tweak advanced parameters using the input
 fields at the top of the page. A second canvas shows a visualisation of the
-neural network used by the first ant. No server or build step is required.
+neural network used by the first ant. Neuron activations and labels are
+displayed so you can see how inputs translate to outputs. No server or build
+step is required.
 
 ## Repository Structure
 
 - `main.html` – entry point that loads all scripts
 - `css/` – style sheets
 - `js/` – JavaScript source files
-- `js/network_viz.js` – draws a small visualisation of the first ant's brain
+- `js/network_viz.js` – draws a visualisation of the first ant's brain with activation values and labels
 - `docs/` – project documentation
 
 See `docs/architecture.md` for a high level overview.

--- a/test/brain.test.js
+++ b/test/brain.test.js
@@ -24,3 +24,12 @@ test('Brain process outputs a unit direction', () => {
   const mag = Math.hypot(dx, dy);
   assert.ok(Math.abs(mag - 1) < 1e-6);
 });
+
+test('Brain stores activations from last process call', () => {
+  const brain = new Brain(3, 2, 2);
+  const inp = [0.1, 0.2, 0.3];
+  brain.process(inp);
+  assert.deepStrictEqual(brain.lastInput, inp);
+  assert.strictEqual(brain.lastHidden.length, brain.hiddenSize);
+  assert.strictEqual(brain.lastOutput.length, 3);
+});


### PR DESCRIPTION
## Summary
- track last activations in `Brain.process`
- show node labels and activation values in `NetworkViz`
- document the improved visualisation
- update README usage section
- test that brain stores activations

## Testing
- `npm test`