### PR TITLE
Expose initialFood configuration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,9 @@ quickly.
 A simple configuration object is passed to `Simulation`, `Environment` and
 `Ant` to control parameters like canvas size, food spawn rate and energy
 behaviour. These parameters are exposed in `main.html` so users can tweak the
-simulation without modifying the code.
+simulation without modifying the code. One such option is `initialFood`, which
+sets the number of food objects that exist when the environment is first
+created.
 Any future parameters that meaningfully change the simulation should also be
 added to this configuration so they remain user controllable.
 

--- a/js/environment.js
+++ b/js/environment.js
@@ -3,6 +3,7 @@ class Environment {
         this.width = config.width || 800;
         this.height = config.height || 600;
         this.maxFood = config.maxFood || 50;
+        this.initialFood = config.initialFood || 10;
         this.foodSpawnChance = config.foodSpawnChance || 0.02;
         this.obstacleCount = config.obstacleCount || 5;
         this.food = [];
@@ -14,6 +15,12 @@ class Environment {
                 y: Math.random() * (this.height - 40),
                 w: 20 + Math.random() * 20,
                 h: 20 + Math.random() * 20
+            });
+        }
+        for (let i = 0; i < this.initialFood && this.food.length < this.maxFood; i++) {
+            this.food.push({
+                x: Math.random() * this.width,
+                y: Math.random() * this.height
             });
         }
     }

--- a/js/main.js
+++ b/js/main.js
@@ -65,6 +65,7 @@ window.addEventListener('load', () => {
             maxAnts: parseInt(document.getElementById('maxAntsInput').value, 10) || 20,
             foodSpawnChance: parseFloat(document.getElementById('foodSpawnInput').value) || 0.02,
             maxFood: parseInt(document.getElementById('maxFoodInput').value, 10) || 50,
+            initialFood: parseInt(document.getElementById('initialFoodInput').value, 10) || 10,
             reproductionEnergyThreshold: parseInt(document.getElementById('reproEnergyInput').value, 10) || 120,
             reproductionEnergyCost: parseInt(document.getElementById('reproCostInput').value, 10) || 40,
             energyDecayRate: parseFloat(document.getElementById('energyDecayInput').value) || 0.1,

--- a/main.html
+++ b/main.html
@@ -15,6 +15,7 @@
         <label>Max ants: <input type="number" id="maxAntsInput" value="20" min="1"></label>
         <label>Food spawn chance: <input type="number" id="foodSpawnInput" value="0.02" step="0.01" min="0" max="1"></label>
         <label>Max food: <input type="number" id="maxFoodInput" value="50" min="1"></label>
+        <label>Initial food: <input type="number" id="initialFoodInput" value="10" min="0"></label>
         <label>Reproduce energy: <input type="number" id="reproEnergyInput" value="120" min="1"></label>
         <label>Reproduction cost: <input type="number" id="reproCostInput" value="40" min="0"></label>
         <label>Energy decay: <input type="number" id="energyDecayInput" value="0.1" step="0.01" min="0"></label>

--- a/readme.md
+++ b/readme.md
@@ -8,10 +8,11 @@ behaviours through small neural networks that mutate when food is plentiful.
 Open `main.html` in any modern browser. The page will display a canvas with a
 population of ants seeking out food that appears over time. Before starting you
 can set how many ants to spawn and tweak advanced parameters using the input
-fields at the top of the page. A second canvas shows a visualisation of the
-neural network used by the first ant. Neuron activations and labels are
-displayed so you can see how inputs translate to outputs. No server or build
-step is required.
+fields at the top of the page. One of these options, **Initial food**, controls
+how many food items are placed in the environment when the simulation begins.
+A second canvas shows a visualisation of the neural network used by the first
+ant. Neuron activations and labels are displayed so you can see how inputs
+translate to outputs. No server or build step is required.
 
 ## Repository Structure
 

--- a/test/environment.test.js
+++ b/test/environment.test.js
@@ -11,3 +11,9 @@ test('Environment spawns food when random condition met', () => {
   Math.random = origRandom;
   assert.strictEqual(env.food.length, 1);
 });
+
+test('Environment creates initial food items', () => {
+  const env = new Environment({initialFood: 5});
+  assert.strictEqual(env.food.length, 5);
+});
+


### PR DESCRIPTION
## Summary
- add `initialFood` option to Environment
- expose input field for initial food count
- pass the value through Simulation config
- document the setting in README and architecture notes
- test that Environment constructor uses the option

## Testing
- `npm test`