### PR TITLE
Add simulation stats panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -14,3 +14,8 @@ canvas {
 #networkCanvas {
     margin-top: 10px;
 }
+
+#stats {
+    margin: 10px 0;
+    font-weight: bold;
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,9 @@ added to this configuration so they remain user controllable.
   ants must navigate around.
 - **Evolution**: When an ant has high energy it creates a mutated offspring,
   giving rise to a simple genetic algorithm.
+- **Stats panel**: A small element below the start button shows the number of
+  ants, food items and average energy each frame so the simulation's progress
+  can be monitored.
 
 ## Running
 

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,8 @@ class Simulation {
         this.reproCost = config.reproductionEnergyCost || 40;
         this.mutationRate = config.mutationRate || 0.2;
         this.networkViz = new NetworkViz('networkCanvas');
+        this.statsEl = document.getElementById('stats');
+        this.stepCount = 0;
     }
 
     update() {
@@ -34,6 +36,8 @@ class Simulation {
             }
         });
         this.ants.push(...newAnts);
+        this.stepCount++;
+        this._updateStats();
     }
 
     draw() {
@@ -42,6 +46,15 @@ class Simulation {
         if (this.ants[0]) {
             this.networkViz.draw(this.ants[0].brain);
         }
+    }
+
+    _updateStats() {
+        if (!this.statsEl) return;
+        const avgEnergy = this.ants.reduce((sum, a) => sum + a.energy, 0) /
+            (this.ants.length || 1);
+        this.statsEl.textContent =
+            `Ants: ${this.ants.length} | Food: ${this.environment.food.length}` +
+            ` | Step: ${this.stepCount} | Avg energy: ${avgEnergy.toFixed(1)}`;
     }
 
     step() {

--- a/main.html
+++ b/main.html
@@ -26,6 +26,7 @@
         <label>Canvas height: <input type="number" id="heightInput" value="600" min="100"></label>
     </details>
     <button id="startBtn">Start</button>
+    <div id="stats"></div>
     <canvas id="simulationCanvas" width="800" height="600"></canvas>
     <h2>Brain Visualisation</h2>
     <canvas id="networkCanvas" width="300" height="150"></canvas>

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,9 @@ fields at the top of the page. One of these options, **Initial food**, controls
 how many food items are placed in the environment when the simulation begins.
 A second canvas shows a visualisation of the neural network used by the first
 ant. Neuron activations and labels are displayed so you can see how inputs
-translate to outputs. No server or build step is required.
+translate to outputs. A small stats line under the start button shows how many
+ants are alive, how much food exists and the average energy as the simulation
+runs. No server or build step is required.
 
 ## Repository Structure
 

--- a/test/simulation.test.js
+++ b/test/simulation.test.js
@@ -12,7 +12,10 @@ const Simulation = require('../js/main.js');
 
 // minimal DOM stubs
 global.document = {
-  getElementById: () => ({ getContext: () => ({}) })
+  getElementById: (id) => {
+    if (id === 'stats') return { textContent: '' };
+    return { getContext: () => ({}) };
+  }
 };
 
 test('Simulation reproduces when energy threshold exceeded', () => {


### PR DESCRIPTION
## Summary
- show overall simulation stats like ant count and food count
- style and place stats panel in the UI
- document the new feature
- update tests for DOM stub

## Testing
- `npm test`