### PR TITLE
Add energy bar above ants

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,8 @@ added to this configuration so they remain user controllable.
 ## Additional Features
 
 - **Energy**: Ants lose energy as they move and regain it when eating food. The
-  colour of each ant reflects its current energy level.
+  colour of each ant reflects its current energy level. A tiny blue bar above
+  each ant indicates the remaining energy ratio.
 - **Pheromones**: A grid based map stores pheromone levels for each cell.
   Ants may deposit pheromone through an actor and the levels decay over time.
   Sensors provide the direction to the strongest cell so ants can follow

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -12,4 +12,4 @@ already been implemented in the codebase.
 - [ ] Create a central nest that ants can return to with food.
 - [x] Remove dead ants from `Simulation.ants` once energy runs out.
 - [ ] Move pheromone decay logic to `Environment.updatePheromones()`.
-- [ ] Draw a small energy bar above each ant for quick status feedback.
+- [x] Draw a small energy bar above each ant for quick status feedback.

--- a/js/ant.js
+++ b/js/ant.js
@@ -54,6 +54,16 @@ class Ant {
         ctx.beginPath();
         ctx.arc(this.x, this.y, 3, 0, Math.PI * 2);
         ctx.fill();
+
+        // small energy bar above the ant
+        const barWidth = 6;
+        const barHeight = 2;
+        const barX = this.x - barWidth / 2;
+        const barY = this.y - 5;
+        ctx.fillStyle = '#0000ff';
+        ctx.fillRect(barX, barY, barWidth * ratio, barHeight);
+        ctx.strokeStyle = '#000';
+        ctx.strokeRect(barX, barY, barWidth, barHeight);
     }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,8 @@ A second canvas shows a visualisation of the neural network used by the first
 ant. Neuron activations and labels are displayed so you can see how inputs
 translate to outputs. A small stats line under the start button shows how many
 ants are alive, how much food exists and the average energy as the simulation
-runs. No server or build step is required.
+runs. Each ant also displays a tiny blue bar above it representing its current
+energy level. No server or build step is required.
 
 ## Repository Structure
 


### PR DESCRIPTION
## Summary
- draw a tiny energy bar over each ant
- describe the bar in architecture docs
- mark energy bar task complete
- mention bar in README usage notes

## Testing
- `npm test`
