### PR TITLE
Fix network visualization output alignment

### DIFF
--- a/js/brain.js
+++ b/js/brain.js
@@ -40,8 +40,11 @@ class Brain {
         const dirY = raw[1] / mag;
         const speed = inputs[2];
         const deposit = sigmoid(raw[2]);
-        this.lastOutput = [dirX, dirY, speed, deposit];
-        return this.lastOutput;
+        // lastOutput is used by the network visualisation which expects only
+        // the three actual network outputs. Speed is not produced by the
+        // network so we omit it here.
+        this.lastOutput = [dirX, dirY, deposit];
+        return [dirX, dirY, speed, deposit];
     }
 }
 

--- a/test/brain.test.js
+++ b/test/brain.test.js
@@ -31,5 +31,7 @@ test('Brain stores activations from last process call', () => {
   brain.process(inp);
   assert.deepStrictEqual(brain.lastInput, inp);
   assert.strictEqual(brain.lastHidden.length, brain.hiddenSize);
-  assert.strictEqual(brain.lastOutput.length, 4);
+  // lastOutput excludes the speed value used by the actors, so it should only
+  // contain the three real network outputs.
+  assert.strictEqual(brain.lastOutput.length, 3);
 });


### PR DESCRIPTION
## Summary
- ensure Brain.lastOutput omits speed value so NetworkViz shows the correct outputs
- update corresponding unit test

## Testing
- `npm test`